### PR TITLE
Correct typo in french translation

### DIFF
--- a/overlay/device/xiaomi/davinci/parts/res/values-fr/strings.xml
+++ b/overlay/device/xiaomi/davinci/parts/res/values-fr/strings.xml
@@ -34,5 +34,5 @@
 
     <!-- Pick-up to wake gesture-->
     <string name="wake_gesture_title">Réveiller</string>
-    <string name="wake_gesture_summary">Réveille l'appareil à la place d\'afficher les notifications pulsantes</string>
+    <string name="wake_gesture_summary">Réveille l\'appareil à la place d\'afficher les notifications pulsantes</string>
 </resources>


### PR DESCRIPTION
Add missing \ in french translation